### PR TITLE
[Typing] MyPy/Pylance error for button decorator

### DIFF
--- a/src/admin_extra_buttons/types.pyi
+++ b/src/admin_extra_buttons/types.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Protocol, TypeAlias, overload
+from typing import Any, Protocol, TypeAlias
 
 from django.db.models import Model
 from django.http import HttpRequest, HttpResponse
@@ -23,16 +23,20 @@ class WidgetProtocol(Protocol):
     def get_button_params(self, context: RequestContext, **extra: Any) -> dict[str, Any]: ...
     def get_button(self, context: RequestContext) -> ButtonWidget: ...
 
-class HandlerFunction:
-    extra_buttons_handler: BaseExtraHandler
+class BaseHandlerFunction(Protocol):
     __name__: str
+    extra_buttons_handler: BaseExtraHandler
 
-    @overload
+class HandlerFunctionRequestAndPk(BaseHandlerFunction, Protocol):
     def __call__(self, model_admin: ExtraButtonsMixin, request: HttpRequest, pk: str) -> HttpResponse: ...
-    @overload
+
+class HandlerFunctionRequest(BaseHandlerFunction, Protocol):
     def __call__(self, model_admin: ExtraButtonsMixin, request: HttpRequest) -> HttpResponse: ...
-    @overload
+
+class HandlerFunctionButton(BaseHandlerFunction, Protocol):
     def __call__(self, model_admin: ExtraButtonsMixin, button: VisibleButton) -> None: ...
+
+HandlerFunction = Union[HandlerFunctionRequestAndPk, HandlerFunctionRequest, HandlerFunctionButton]
 
 LinkHandlerFunction: TypeAlias = HandlerFunction
 


### PR DESCRIPTION
# Introduction
This issue has already been considered: https://github.com/saxix/django-admin-extra-buttons/issues/29
## Code usage (taken from the first page of the documentation)
```python
class Admin1(ExtraButtonsMixin, admin.ModelAdmin):
    list_filter = [TestFilter]

    @button(permission="demo.add_demomodel1", change_form=True, change_list=False, html_attrs={"class": "aeb-green"})
    def refresh(self, request):
        self.message_user(request, "refresh called")
```
## Microsoft PyLance Problem
```
Argument of type "(self: Self@GiftModelAdmin, request: Unknown) -> None" cannot be assigned to parameter of type "HandlerFunction"
  "FunctionType" is not assignable to "HandlerFunction"Pylance[reportArgumentType](https://github.com/microsoft/pylance-release/blob/main/docs/diagnostics/reportArgumentType.md)
  ```
  ## What I use
1.   Pylance 2025.7.1
2.   Python 3.13.4
3.   Django 5.2.1
4.   Django Admin Extra Buttons 2.1.1

  # Technical details
  I split HandlerFunction into three protocols and linked them via union. Otherwise, using typing.overload, we get warnings from type analyzers and language servers. This happens because overload annotations in Protocol describe several overloaded signatures, and a regular function (or callable object) must have one real implementation compatible with all these signatures. I fixed the code and closed the cause of incompatibility.
  