### PR TITLE
updated docs for button()'s permission lambda

### DIFF
--- a/docs/src/api/button.md
+++ b/docs/src/api/button.md
@@ -70,7 +70,7 @@ class MyModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
     bool or callable show/hide button. The callable takes the `ButtonWidget` instance as a unique argument ; this argument gives access to the `request`, the template `context`, and the `original` object the is being edited in the admin.
 
 `permission` (defaults to `None`):
-    Django permission code needed to access the view and display the button, or a callable that takes the `request` and the edited `object` as arguments and that must return a `bool`.
+    Django permission code needed to access the view and display the button, or a callable that takes the `request`, edited `object`, and `handler` as arguments and that must return a `bool`.
 
 !!! Note
 
@@ -123,7 +123,7 @@ Two complex buttons, one for `change_list` with custom permission, and one for `
 @register(MyModel)
 class MyModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
 
-    @button(permission=lambda request, obj: request.user.is_superuser,
+    @button(permission=lambda request, obj, handler: request.user.is_superuser,
             html_attrs={'style': 'background-color:var(--button-bg)'},
             label=_('Delete All Records'),
             )

--- a/docs/src/api/button.md
+++ b/docs/src/api/button.md
@@ -102,7 +102,7 @@ Buttons with custom permission, one for `change_list` and other for `change_form
 @register(MyModel)
 class MyModelAdmin(ExtraButtonsMixin, admin.ModelAdmin):
 
-    @button(permission=lambda request, obj: request.user.is_superuser)
+    @button(permission=lambda request, obj, handler: request.user.is_superuser)
     def delete_all(self, request):
         pass
 


### PR DESCRIPTION
I'm unsure about other Python versions, but under Python 3.13, the doc for button()'s permission doesn't work. The following error is the reason.

```TypeError: Admin.<lambda>() got an unexpected keyword argument 'handler'```

The fix update is to add handler to the lambda.